### PR TITLE
Use reqwest proxy api instead

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+flynnlabs.dev

--- a/index.html
+++ b/index.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <link href="https://fonts.googleapis.com/css?family=Helvetica:300,400,500" rel="stylesheet">
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css?family=Overpass%20Mono:700|Overpass%20Mono:400" rel="stylesheet">
         <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
~~This is enabled after [this change upstream](https://gitlab.com/flynneva/ncaa-data-rs/-/commit/99aa87ea9d6ecc84e7c7c2dac4197158f46f6564) to the `ncaa_data_rs` crate to use the reqwest Proxy API directly for its queries.~~

So reqwest's proxy api [doesnt work for wasm sites](https://github.com/seanmonstar/reqwest/issues/2504), so hijacking this PR to instead continue with normal requests, but I've setup a cloudflare proxy now for the site.

Hopefully this works 😅 